### PR TITLE
Add password policy options

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -30,9 +30,10 @@ resource "aws_iam_user_group_membership" "groups" {
 
 # security/password
 resource "random_password" "password" {
-  count   = local.login_on == true ? 1 : 0
-  length  = 16
-  special = true
+  count            = local.login_on == true ? 1 : 0
+  length           = lookup(var.password_policy, "length", 16)
+  special          = true
+  override_special = "!@#$%^&*()_+-=[]{}|'"
 }
 
 # login profile

--- a/variables.tf
+++ b/variables.tf
@@ -27,3 +27,8 @@ variable "desc" {
   description = "The extra description of user"
   default     = "Managed by Terraform"
 }
+
+variable "password_policy" {
+  description = "The policy of password string"
+  default     = { "length" = 16 }
+}


### PR DESCRIPTION
This PR is related to https://github.com/tf-mod/terraform-aws-rbac-user/issues/1.

* Restrict special characters in password.
* Add variable `password_policy` to set length of password.