### PR TITLE
Update login-profile creation CLI to support govcloud

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -57,12 +57,14 @@ resource "local_file" "login-profile" {
   file_permission   = "0600"
 }
 
+data "aws_region" "current" {}
+
 resource "null_resource" "login-profile" {
   depends_on = [local_file.login-profile]
   count      = local.login_on == true ? 1 : 0
   provisioner "local-exec" {
     command = <<CLI
-aws iam create-login-profile --cli-input-json file://${local.creds_filepath} --region us-east-1
+aws iam create-login-profile --cli-input-json file://${local.creds_filepath} --region ${data.aws_region.current.name}
 CLI
   }
 }


### PR DESCRIPTION
Since the AWS region information is hard-coded, it has to be updated in order to support GovCloud