### PR TITLE
Enhance pw generator

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -35,6 +35,13 @@ resource "random_password" "password" {
   special = true
 }
 
+# security/password suffix
+resource "random_integer" "suffix" {
+  count   = local.login_on == true ? 1 : 0
+  min     = 1
+  max     = 99
+}
+
 # login profile
 data "template_file" "login-profile" {
   count    = local.login_on == true ? 1 : 0
@@ -42,7 +49,7 @@ data "template_file" "login-profile" {
 
   vars = {
     name     = aws_iam_user.user.name
-    password = random_password.password[0].result
+    password = format("%s%s", random_password.password[0].result, random_integer.suffix[0].result)
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -57,12 +57,14 @@ resource "local_file" "login-profile" {
   file_permission   = "0600"
 }
 
+data "aws_region" "current" {}
+
 resource "null_resource" "login-profile" {
   depends_on = [local_file.login-profile]
   count      = local.login_on == true ? 1 : 0
   provisioner "local-exec" {
     command = <<CLI
-aws iam create-login-profile --cli-input-json file://${local.creds_filepath} --region us-east-1
+aws iam create-login-profile --cli-input-json file://${local.creds_filepath} --region ${data.aws_region.current.name}
 CLI
   }
 }


### PR DESCRIPTION
To support the newly updated AWS's password policy, we should add at least one number to the password.
(https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_passwords_account-policy.html)

Related error:
```
An error occurred (PasswordPolicyViolation) when calling the CreateLoginProfile operation: Password should have at least one number
```


